### PR TITLE
Add backend for CRUD operations for RecommendatioRequests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -1,0 +1,129 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException; // Added this import
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "RecommendationRequest")
+@RequestMapping("/api/RecommendationRequest")
+@RestController
+@Slf4j
+public class RecommendationRequestController extends ApiController {
+
+  @Autowired RecommendationRequestRepository recommendationRequestRepository;
+
+  @Operation(summary = "List all recommendation requests")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<RecommendationRequest> allRecommendationRequests() {
+    Iterable<RecommendationRequest> requests = recommendationRequestRepository.findAll();
+    return requests;
+  }
+
+  @Operation(summary = "Create a new recommendation request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public RecommendationRequest postRecommendationRequest(
+      @Parameter(name = "requesterEmail") @RequestParam String requesterEmail,
+      @Parameter(name = "professorEmail") @RequestParam String professorEmail,
+      @Parameter(name = "explanation") @RequestParam String explanation,
+      @Parameter(
+              name = "dateRequested",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateRequested")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateRequested,
+      @Parameter(
+              name = "dateNeeded",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateNeeded")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateNeeded,
+      @Parameter(name = "done") @RequestParam boolean done) {
+
+    log.info(
+        "postRecommendationRequest: requesterEmail={}, professorEmail={}, done={}",
+        requesterEmail,
+        professorEmail,
+        done);
+
+    RecommendationRequest request = new RecommendationRequest();
+    request.setRequesterEmail(requesterEmail);
+    request.setProfessorEmail(professorEmail);
+    request.setExplanation(explanation);
+    request.setDateRequested(dateRequested);
+    request.setDateNeeded(dateNeeded);
+    request.setDone(done);
+
+    RecommendationRequest savedRequest = recommendationRequestRepository.save(request);
+
+    return savedRequest;
+  }
+
+  @Operation(summary = "Get a single recommendation request")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public RecommendationRequest getById(@Parameter(name = "id") @RequestParam Long id) {
+
+    RecommendationRequest recommendationRequest =
+        recommendationRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+    return recommendationRequest;
+  }
+
+  @Operation(summary = "Update a single recommendation request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public RecommendationRequest updateRecommendationRequest(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody RecommendationRequest incoming) {
+
+    RecommendationRequest recommendationRequest =
+        recommendationRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+    recommendationRequest.setRequesterEmail(incoming.getRequesterEmail());
+    recommendationRequest.setProfessorEmail(incoming.getProfessorEmail());
+    recommendationRequest.setExplanation(incoming.getExplanation());
+    recommendationRequest.setDateRequested(incoming.getDateRequested());
+    recommendationRequest.setDateNeeded(incoming.getDateNeeded());
+    recommendationRequest.setDone(incoming.getDone());
+
+    recommendationRequestRepository.save(recommendationRequest);
+
+    return recommendationRequest;
+  }
+
+  @Operation(summary = "Delete a recommendation request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteRecommendationRequest(@Parameter(name = "id") @RequestParam Long id) {
+    RecommendationRequest recommendationRequest =
+        recommendationRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+    recommendationRequestRepository.delete(recommendationRequest);
+    return genericMessage("RecommendationRequest with id %d deleted".formatted(id));
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "RecommendationRequest")
+public class RecommendationRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String professorEmail;
+  private String explanation;
+  private LocalDateTime dateRequested;
+  private LocalDateTime dateNeeded;
+  private boolean done;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecommendationRequestRepository
+    extends CrudRepository<RecommendationRequest, Long> {}

--- a/src/main/resources/db/migration/changes/RecommendationRequest.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequest.json
@@ -1,0 +1,68 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "RecommendationRequest-1",
+        "author": "hrithik",
+        "changes": [
+          {
+            "createTable": {
+              "tableName": "recommendation_request",
+              "columns": [
+                {
+                  "column": {
+                    "name": "id",
+                    "type": "bigint",
+                    "autoIncrement": true,
+                    "constraints": { "primaryKey": true }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "requester_email",
+                    "type": "varchar(255)",
+                    "constraints": { "nullable": false }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "professor_email",
+                    "type": "varchar(255)",
+                    "constraints": { "nullable": false }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "explanation",
+                    "type": "varchar(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "date_requested",
+                    "type": "datetime",
+                    "constraints": { "nullable": false }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "date_needed",
+                    "type": "datetime",
+                    "constraints": { "nullable": false }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "done",
+                    "type": "boolean",
+                    "constraints": { "nullable": false }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -1,0 +1,326 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = RecommendationRequestController.class)
+@Import(TestConfig.class)
+public class RecommendationRequestControllerTests extends ControllerTestCase {
+
+  @MockBean RecommendationRequestRepository recommendationRequestRepository;
+
+  @MockBean UserRepository userRepository;
+
+  // Authorization tests for /all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/RecommendationRequest/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/RecommendationRequest/all")).andExpect(status().is(200));
+  }
+
+  // Authorization tests for /post
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/RecommendationRequest/post")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/RecommendationRequest/post")).andExpect(status().is(403));
+  }
+
+  // Tests for GET /all
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_recommendationrequests() throws Exception {
+
+    LocalDateTime dr1 = LocalDateTime.parse("2026-04-20T00:00:00");
+    LocalDateTime dn1 = LocalDateTime.parse("2026-05-20T00:00:00");
+
+    RecommendationRequest req1 =
+        RecommendationRequest.builder()
+            .requesterEmail("user1@ucsb.edu")
+            .professorEmail("prof1@ucsb.edu")
+            .explanation("Grad School")
+            .dateRequested(dr1)
+            .dateNeeded(dn1)
+            .done(false)
+            .build();
+
+    ArrayList<RecommendationRequest> expectedRequests = new ArrayList<>();
+    expectedRequests.addAll(Arrays.asList(req1));
+
+    when(recommendationRequestRepository.findAll()).thenReturn(expectedRequests);
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/RecommendationRequest/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedRequests);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  // Tests for POST /post
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_recommendationrequest() throws Exception {
+    LocalDateTime dr1 = LocalDateTime.parse("2026-04-20T00:00:00");
+    LocalDateTime dn1 = LocalDateTime.parse("2026-05-20T00:00:00");
+
+    RecommendationRequest req1 =
+        RecommendationRequest.builder()
+            .requesterEmail("student@ucsb.edu")
+            .professorEmail("pconrad@ucsb.edu")
+            .explanation("Masters Program")
+            .dateRequested(dr1)
+            .dateNeeded(dn1)
+            .done(true)
+            .build();
+
+    when(recommendationRequestRepository.save(eq(req1))).thenReturn(req1);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/RecommendationRequest/post")
+                    .param("requesterEmail", "student@ucsb.edu")
+                    .param("professorEmail", "pconrad@ucsb.edu")
+                    .param("explanation", "Masters Program")
+                    .param("dateRequested", "2026-04-20T00:00:00")
+                    .param("dateNeeded", "2026-05-20T00:00:00")
+                    .param("done", "true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).save(req1);
+    String expectedJson = mapper.writeValueAsString(req1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  // Tests for GET /?id=...
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_getById_returns_error_when_id_does_not_exist() throws Exception {
+
+    when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/RecommendationRequest?id=7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_getById_returns_request_when_id_exists() throws Exception {
+
+    LocalDateTime dr = LocalDateTime.parse("2026-04-20T00:00:00");
+    LocalDateTime dn = LocalDateTime.parse("2026-05-20T00:00:00");
+
+    RecommendationRequest req =
+        RecommendationRequest.builder()
+            .requesterEmail("student@ucsb.edu")
+            .professorEmail("prof@ucsb.edu")
+            .explanation("Grad School")
+            .dateRequested(dr)
+            .dateNeeded(dn)
+            .done(false)
+            .build();
+
+    when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.of(req));
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/RecommendationRequest?id=7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(req);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  // Tests for PUT /?id=...
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_recommendationrequest() throws Exception {
+    LocalDateTime dr1 = LocalDateTime.parse("2026-04-20T00:00:00");
+    LocalDateTime dn1 = LocalDateTime.parse("2026-05-20T00:00:00");
+    LocalDateTime dr2 = LocalDateTime.parse("2026-04-21T00:00:00");
+    LocalDateTime dn2 = LocalDateTime.parse("2026-05-21T00:00:00");
+
+    RecommendationRequest reqOrig =
+        RecommendationRequest.builder()
+            .requesterEmail("orig@ucsb.edu")
+            .professorEmail("proforig@ucsb.edu")
+            .explanation("Orig Explanation")
+            .dateRequested(dr1)
+            .dateNeeded(dn1)
+            .done(false)
+            .build();
+
+    RecommendationRequest reqEdited =
+        RecommendationRequest.builder()
+            .requesterEmail("new@ucsb.edu")
+            .professorEmail("profnew@ucsb.edu")
+            .explanation("New Explanation")
+            .dateRequested(dr2)
+            .dateNeeded(dn2)
+            .done(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(reqEdited);
+
+    when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(reqOrig));
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/RecommendationRequest?id=67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findById(67L);
+    verify(recommendationRequestRepository, times(1)).save(reqEdited);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_recommendationrequest_that_does_not_exist() throws Exception {
+    LocalDateTime dr1 = LocalDateTime.parse("2026-04-20T00:00:00");
+    LocalDateTime dn1 = LocalDateTime.parse("2026-05-20T00:00:00");
+
+    RecommendationRequest reqEdited =
+        RecommendationRequest.builder()
+            .requesterEmail("new@ucsb.edu")
+            .professorEmail("profnew@ucsb.edu")
+            .explanation("New Explanation")
+            .dateRequested(dr1)
+            .dateNeeded(dn1)
+            .done(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(reqEdited);
+
+    when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/RecommendationRequest?id=67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findById(67L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("RecommendationRequest with id 67 not found", json.get("message"));
+  }
+
+  // Tests for DELETE
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_a_request() throws Exception {
+    LocalDateTime dr = LocalDateTime.parse("2026-04-20T00:00:00");
+    LocalDateTime dn = LocalDateTime.parse("2026-05-20T00:00:00");
+
+    RecommendationRequest req =
+        RecommendationRequest.builder()
+            .requesterEmail("student@ucsb.edu")
+            .professorEmail("prof@ucsb.edu")
+            .explanation("Grad School")
+            .dateRequested(dr)
+            .dateNeeded(dn)
+            .done(false)
+            .build();
+
+    when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.of(req));
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/RecommendationRequest?id=15").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findById(15L);
+    verify(recommendationRequestRepository, times(1)).delete(req);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("RecommendationRequest with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existent_request_and_gets_right_error_message()
+      throws Exception {
+    when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/RecommendationRequest?id=15").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(recommendationRequestRepository, times(1)).findById(15L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("RecommendationRequest with id 15 not found", json.get("message"));
+  }
+}


### PR DESCRIPTION
The backend CRUD operations for RecommendationRequest are implemented by copying the required components from the team01 project This includes the database entity, the JPA repository, the REST controller, and the controller tests.

The following files were added/updated:
Entity: RecommendationRequest.java in entities
Repository: RecommendationRequestRepository.java in repositories
Controller: RecommendationRequestController.java in controllers
Tests: RecommendationRequestControllerTests.java in test/.../controllers
Migration: Database migration script added to src/main/resources/db/migration/changes

Link to Dokku deployment: https://team02-hrithik-m-dev.dokku-03.cs.ucsb.edu/
Link to swagger link: https://team02-hrithik-m-dev.dokku-03.cs.ucsb.edu/swagger-ui/index.html

Closes #20 