### PR TITLE
Copied from team01

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,127 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for UCSBOrganization */
+@Tag(name = "UCSBOrganization")
+@RequestMapping("/api/UCSBOrganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+  @Autowired UCSBOrganizationRepository ucsbOrganizationRepository;
+
+  /**
+   * This method returns a list of all UCSB organizations.
+   *
+   * @return a list of all UCSB organizations
+   */
+  @Operation(summary = "List all UCSB organizations")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBOrganization> allOrganizations() {
+    Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
+    return organizations;
+  }
+
+  @Operation(summary = "Get a single UCSB organization")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBOrganization getById(
+      @Parameter(name = "orgCode") @RequestParam(required = false) String orgCode,
+      @Parameter(name = "id") @RequestParam(required = false) String id) {
+    String lookupOrgCode = orgCode != null ? orgCode : id;
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(lookupOrgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, lookupOrgCode));
+
+    return organization;
+  }
+
+  /**
+   * This method creates a new UCSB organization. Accessible only to users with the role
+   * "ROLE_ADMIN".
+   *
+   * @param orgCode organization code
+   * @param orgTranslationShort short organization translation
+   * @param orgTranslation organization translation
+   * @param inactive whether the organization is inactive
+   * @return the saved UCSB organization
+   */
+  @Operation(summary = "Create a new UCSB organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBOrganization postOrganization(
+      @Parameter(name = "orgCode") @RequestParam String orgCode,
+      @Parameter(name = "orgTranslationShort") @RequestParam String orgTranslationShort,
+      @Parameter(name = "orgTranslation") @RequestParam String orgTranslation,
+      @Parameter(name = "inactive") @RequestParam boolean inactive) {
+
+    UCSBOrganization organization = new UCSBOrganization();
+    organization.setOrgCode(orgCode);
+    organization.setOrgTranslationShort(orgTranslationShort);
+    organization.setOrgTranslation(orgTranslation);
+    organization.setInactive(inactive);
+
+    UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organization);
+
+    return savedOrganization;
+  }
+
+  @Operation(summary = "Update a single UCSB organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public UCSBOrganization updateOrganization(
+      @Parameter(name = "orgCode") @RequestParam(required = false) String orgCode,
+      @Parameter(name = "id") @RequestParam(required = false) String id,
+      @RequestBody @Valid UCSBOrganization incoming) {
+    String lookupOrgCode = orgCode != null ? orgCode : id;
+
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(lookupOrgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, lookupOrgCode));
+
+    organization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+    organization.setOrgTranslation(incoming.getOrgTranslation());
+    organization.setInactive(incoming.getInactive());
+
+    ucsbOrganizationRepository.save(organization);
+
+    return organization;
+  }
+
+  @Operation(summary = "Delete a UCSB organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteOrganization(
+      @Parameter(name = "orgCode") @RequestParam(required = false) String orgCode,
+      @Parameter(name = "id") @RequestParam(required = false) String id) {
+    String lookupOrgCode = orgCode != null ? orgCode : id;
+    UCSBOrganization organization =
+        ucsbOrganizationRepository
+            .findById(lookupOrgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, lookupOrgCode));
+
+    ucsbOrganizationRepository.delete(organization);
+    return genericMessage("record %s deleted".formatted(lookupOrgCode));
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganizations")
+public class UCSBOrganization {
+
+  @Id private String orgCode;
+
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,8 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -1,0 +1,62 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "UCSBOrganization-1",
+        "author": "POWERTRICEPS",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "UCSBORGANIZATIONS"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "tableName": "UCSBORGANIZATIONS",
+              "columns": [
+                {
+                  "column": {
+                    "name": "ORG_CODE",
+                    "type": "VARCHAR(255)",
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "UCSBORGANIZATIONS_PK",
+                      "nullable": false
+                    }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ORG_TRANSLATION_SHORT",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ORG_TRANSLATION",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "INACTIVE",
+                    "type": "BOOLEAN"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,469 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+  @MockitoBean UCSBOrganizationRepository ucsbOrganizationRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().is(200));
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/UCSBOrganization").param("id", "ATHLETICS"))
+        .andExpect(status().is(403));
+  }
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/UCSBOrganization/post")
+                .param("orgCode", "ATHLETICS")
+                .param("orgTranslationShort", "Athletics")
+                .param("orgTranslation", "Intercollegiate Athletics")
+                .param("inactive", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/UCSBOrganization/post")
+                .param("orgCode", "ATHLETICS")
+                .param("orgTranslationShort", "Athletics")
+                .param("orgTranslation", "Intercollegiate Athletics")
+                .param("inactive", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @Test
+  public void logged_out_users_cannot_put() throws Exception {
+    UCSBOrganization incoming =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics Updated")
+            .orgTranslation("Updated Athletics")
+            .inactive(false)
+            .build();
+
+    mockMvc
+        .perform(
+            put("/api/UCSBOrganization")
+                .param("id", "ATHLETICS")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(incoming))
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_put() throws Exception {
+    UCSBOrganization incoming =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics Updated")
+            .orgTranslation("Updated Athletics")
+            .inactive(false)
+            .build();
+
+    mockMvc
+        .perform(
+            put("/api/UCSBOrganization")
+                .param("id", "ATHLETICS")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(incoming))
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @Test
+  public void logged_out_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/UCSBOrganization").param("id", "ATHLETICS").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/UCSBOrganization").param("id", "ATHLETICS").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_organizations() throws Exception {
+    UCSBOrganization athletics =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics")
+            .orgTranslation("Intercollegiate Athletics")
+            .inactive(true)
+            .build();
+
+    UCSBOrganization registrar =
+        UCSBOrganization.builder()
+            .orgCode("REGISTRAR")
+            .orgTranslationShort("Registrar")
+            .orgTranslation("Office of the Registrar")
+            .inactive(false)
+            .build();
+
+    ArrayList<UCSBOrganization> expectedOrganizations = new ArrayList<>();
+    expectedOrganizations.addAll(Arrays.asList(athletics, registrar));
+
+    when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganizations);
+
+    MvcResult response =
+        mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().isOk()).andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedOrganizations);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+    UCSBOrganization athletics =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics")
+            .orgTranslation("Intercollegiate Athletics")
+            .inactive(true)
+            .build();
+
+    when(ucsbOrganizationRepository.findById("ATHLETICS")).thenReturn(Optional.of(athletics));
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/UCSBOrganization").param("id", "ATHLETICS"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("ATHLETICS");
+    String expectedJson = mapper.writeValueAsString(athletics);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_orgCode_when_the_orgCode_exists()
+      throws Exception {
+    UCSBOrganization athletics =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics")
+            .orgTranslation("Intercollegiate Athletics")
+            .inactive(true)
+            .build();
+
+    when(ucsbOrganizationRepository.findById("ATHLETICS")).thenReturn(Optional.of(athletics));
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/UCSBOrganization").param("orgCode", "ATHLETICS"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("ATHLETICS");
+    String expectedJson = mapper.writeValueAsString(athletics);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_gets_404_when_the_id_does_not_exist() throws Exception {
+    when(ucsbOrganizationRepository.findById("NOTREAL")).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/UCSBOrganization").param("id", "NOTREAL"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("NOTREAL");
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id NOTREAL not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_an_existing_organization() throws Exception {
+    UCSBOrganization athletics =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics")
+            .orgTranslation("Intercollegiate Athletics")
+            .inactive(true)
+            .build();
+
+    when(ucsbOrganizationRepository.findById("ATHLETICS")).thenReturn(Optional.of(athletics));
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBOrganization").param("id", "ATHLETICS").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("ATHLETICS");
+    verify(ucsbOrganizationRepository, times(1)).delete(any());
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("record ATHLETICS deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_an_existing_organization_by_orgCode() throws Exception {
+    UCSBOrganization athletics =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics")
+            .orgTranslation("Intercollegiate Athletics")
+            .inactive(true)
+            .build();
+
+    when(ucsbOrganizationRepository.findById("ATHLETICS")).thenReturn(Optional.of(athletics));
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBOrganization").param("orgCode", "ATHLETICS").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("ATHLETICS");
+    verify(ucsbOrganizationRepository, times(1)).delete(any());
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("record ATHLETICS deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existant_organization_and_gets_right_error_message()
+      throws Exception {
+    when(ucsbOrganizationRepository.findById("NOTREAL")).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBOrganization").param("id", "NOTREAL").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("NOTREAL");
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id NOTREAL not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_update_an_existing_organization() throws Exception {
+    UCSBOrganization existingOrganization =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics")
+            .orgTranslation("Intercollegiate Athletics")
+            .inactive(true)
+            .build();
+
+    UCSBOrganization incoming =
+        UCSBOrganization.builder()
+            .orgCode("SHOULD_NOT_CHANGE")
+            .orgTranslationShort("Athletics Updated")
+            .orgTranslation("Updated Athletics")
+            .inactive(false)
+            .build();
+
+    UCSBOrganization expectedOrganization =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics Updated")
+            .orgTranslation("Updated Athletics")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById("ATHLETICS"))
+        .thenReturn(Optional.of(existingOrganization));
+    when(ucsbOrganizationRepository.save(expectedOrganization)).thenReturn(expectedOrganization);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/UCSBOrganization")
+                    .param("id", "ATHLETICS")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(mapper.writeValueAsString(incoming))
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("ATHLETICS");
+    verify(ucsbOrganizationRepository, times(1)).save(expectedOrganization);
+    String expectedJson = mapper.writeValueAsString(expectedOrganization);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_update_an_existing_organization_by_orgCode() throws Exception {
+    UCSBOrganization existingOrganization =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics")
+            .orgTranslation("Intercollegiate Athletics")
+            .inactive(true)
+            .build();
+
+    UCSBOrganization incoming =
+        UCSBOrganization.builder()
+            .orgCode("SHOULD_NOT_CHANGE")
+            .orgTranslationShort("Athletics Updated")
+            .orgTranslation("Updated Athletics")
+            .inactive(false)
+            .build();
+
+    UCSBOrganization expectedOrganization =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics Updated")
+            .orgTranslation("Updated Athletics")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById("ATHLETICS"))
+        .thenReturn(Optional.of(existingOrganization));
+    when(ucsbOrganizationRepository.save(expectedOrganization)).thenReturn(expectedOrganization);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/UCSBOrganization")
+                    .param("orgCode", "ATHLETICS")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(mapper.writeValueAsString(incoming))
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("ATHLETICS");
+    verify(ucsbOrganizationRepository, times(1)).save(expectedOrganization);
+    String expectedJson = mapper.writeValueAsString(expectedOrganization);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_update_non_existant_organization_and_gets_right_error_message()
+      throws Exception {
+    UCSBOrganization incoming =
+        UCSBOrganization.builder()
+            .orgCode("NOTREAL")
+            .orgTranslationShort("Not Real")
+            .orgTranslation("Not Real Organization")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById("NOTREAL")).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/UCSBOrganization")
+                    .param("id", "NOTREAL")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(mapper.writeValueAsString(incoming))
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findById("NOTREAL");
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBOrganization with id NOTREAL not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_organization() throws Exception {
+    UCSBOrganization athletics =
+        UCSBOrganization.builder()
+            .orgCode("ATHLETICS")
+            .orgTranslationShort("Athletics")
+            .orgTranslation("Intercollegiate Athletics")
+            .inactive(true)
+            .build();
+
+    when(ucsbOrganizationRepository.save(athletics)).thenReturn(athletics);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/UCSBOrganization/post")
+                    .param("orgCode", "ATHLETICS")
+                    .param("orgTranslationShort", "Athletics")
+                    .param("orgTranslation", "Intercollegiate Athletics")
+                    .param("inactive", "true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).save(athletics);
+    String expectedJson = mapper.writeValueAsString(athletics);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
This PR adds backend CRUD support for UCSBOrganization.

It includes the database entity, JPA repository, REST controller, Liquibase migration, and controller tests for creating, reading, updating, and deleting UCSBOrganization records.

Files added:
- Entity: `UCSBOrganization.java`
- Repository: `UCSBOrganizationRepository.java`
- Controller: `UCSBOrganizationController.java`
- Migration: `UCSBOrganization.json`
- Tests: `UCSBOrganizationControllerTests.java`


Closes #11 

Link to Deployment: https://team02-powertriceps-dev.dokku-03.cs.ucsb.edu
Link to swagger: https://team02-powertriceps-dev.dokku-03.cs.ucsb.edu/swagger-ui/index.html