### PR TITLE
Add UCSBOrganization fixtures

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,0 +1,31 @@
+const ucsbOrganizationFixtures = {
+  oneOrganization: {
+    orgCode: "ARTS",
+    orgTranslationShort: "Arts",
+    orgTranslation: "College of Letters and Science - Arts and Humanities",
+    inactive: false,
+  },
+
+  threeOrganizations: [
+    {
+      orgCode: "ARTS",
+      orgTranslationShort: "Arts",
+      orgTranslation: "College of Letters and Science - Arts and Humanities",
+      inactive: false,
+    },
+    {
+      orgCode: "ENGR",
+      orgTranslationShort: "Engineering",
+      orgTranslation: "College of Engineering",
+      inactive: false,
+    },
+    {
+      orgCode: "EXT",
+      orgTranslationShort: "Extension",
+      orgTranslation: "UCSB Extension",
+      inactive: true,
+    },
+  ],
+};
+
+export { ucsbOrganizationFixtures };


### PR DESCRIPTION
This PR adds frontend fixtures for UCSBOrganization.

The fixture file includes example UCSBOrganization objects that match the JSON shape returned by the backend API, including `orgCode`, `orgTranslationShort`, `orgTranslation`, and `inactive`.

Added:
- `frontend/src/fixtures/ucsbOrganizationFixtures.js`


Closes #12 

Link for Deployment: https://team02-powertriceps-dev.dokku-03.cs.ucsb.edu/