### PR TITLE
Added UCSBOrganization Forms Component

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,0 +1,31 @@
+const ucsbOrganizationFixtures = {
+  oneOrganization: {
+    orgCode: "ARTS",
+    orgTranslationShort: "Arts",
+    orgTranslation: "College of Letters and Science - Arts and Humanities",
+    inactive: false,
+  },
+
+  threeOrganizations: [
+    {
+      orgCode: "ARTS",
+      orgTranslationShort: "Arts",
+      orgTranslation: "College of Letters and Science - Arts and Humanities",
+      inactive: false,
+    },
+    {
+      orgCode: "ENGR",
+      orgTranslationShort: "Engineering",
+      orgTranslation: "College of Engineering",
+      inactive: false,
+    },
+    {
+      orgCode: "EXT",
+      orgTranslationShort: "Extension",
+      orgTranslation: "UCSB Extension",
+      inactive: true,
+    },
+  ],
+};
+
+export { ucsbOrganizationFixtures };

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.jsx
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.jsx
@@ -1,0 +1,99 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function UCSBOrganizationForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "UCSBOrganizationForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="orgCode">Org Code</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-orgCode"}
+          id="orgCode"
+          type="text"
+          isInvalid={Boolean(errors.orgCode)}
+          disabled={Boolean(initialContents)}
+          {...register("orgCode", {
+            required: "Org Code is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.orgCode?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="orgTranslationShort">
+          Org Translation Short
+        </Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-orgTranslationShort"}
+          id="orgTranslationShort"
+          type="text"
+          isInvalid={Boolean(errors.orgTranslationShort)}
+          {...register("orgTranslationShort", {
+            required: "Org Translation Short is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.orgTranslationShort?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="orgTranslation">Org Translation</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-orgTranslation"}
+          id="orgTranslation"
+          type="text"
+          isInvalid={Boolean(errors.orgTranslation)}
+          {...register("orgTranslation", {
+            required: "Org Translation is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.orgTranslation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Check
+          data-testid={testIdPrefix + "-inactive"}
+          id="inactive"
+          type="checkbox"
+          label="Inactive"
+          {...register("inactive")}
+        />
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default UCSBOrganizationForm;

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.jsx
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+
+export default {
+  title: "components/UCSBOrganization/UCSBOrganizationForm",
+  component: UCSBOrganizationForm,
+};
+
+const Template = (args) => {
+  return <UCSBOrganizationForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: ucsbOrganizationFixtures.oneOrganization,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("UCSBOrganizationForm tests", () => {
+  const expectedHeaders = [
+    "Org Code",
+    "Org Translation Short",
+    "Org Translation",
+    "Inactive",
+  ];
+  const testId = "UCSBOrganizationForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <Router>
+        <UCSBOrganizationForm />
+      </Router>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-orgCode`)).not.toBeDisabled();
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <Router>
+        <UCSBOrganizationForm
+          initialContents={ucsbOrganizationFixtures.oneOrganization}
+        />
+      </Router>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-orgCode`)).toHaveValue("ARTS");
+    expect(screen.getByTestId(`${testId}-orgCode`)).toBeDisabled();
+    expect(screen.getByTestId(`${testId}-orgTranslationShort`)).toHaveValue(
+      "Arts",
+    );
+    expect(screen.getByTestId(`${testId}-orgTranslation`)).toHaveValue(
+      "College of Letters and Science - Arts and Humanities",
+    );
+    expect(screen.getByTestId(`${testId}-inactive`)).not.toBeChecked();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <Router>
+        <UCSBOrganizationForm />
+      </Router>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <Router>
+        <UCSBOrganizationForm />
+      </Router>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Org Code is required./);
+    expect(
+      screen.getByText(/Org Translation Short is required./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Org Translation is required./),
+    ).toBeInTheDocument();
+  });
+
+  test("that submitAction is called with good input", async () => {
+    const mockSubmitAction = vi.fn();
+
+    render(
+      <Router>
+        <UCSBOrganizationForm submitAction={mockSubmitAction} />
+      </Router>,
+    );
+
+    fireEvent.change(await screen.findByTestId(`${testId}-orgCode`), {
+      target: { value: "LIBR" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-orgTranslationShort`), {
+      target: { value: "Library" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-orgTranslation`), {
+      target: { value: "UCSB Library" },
+    });
+    fireEvent.click(screen.getByTestId(`${testId}-inactive`));
+    fireEvent.click(screen.getByTestId(`${testId}-submit`));
+
+    await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
This PR adds the frontend form component for `UCSBOrganization`.

The new `UCSBOrganizationForm` component supports both create and update workflows. It includes fields for `orgCode`, `orgTranslationShort`, `orgTranslation`, and `inactive`, matching the backend `UCSBOrganization` object shape. For update workflows, `orgCode` is shown as a disabled/read-only field so the primary key is not changed.

This PR also adds Storybook coverage for both create and update scenarios, plus component tests for rendering, validation, cancel navigation, and successful submission.

<img width="1764" height="948" alt="image" src="https://github.com/user-attachments/assets/2faaff82-403c-4f94-b9f5-e14282bf9f9c" />


Link to storyboard: https://ucsb-cs156-s26.github.io/team02-s26-03/prs/71/
Link to Deployment: https://team02-powertriceps-dev.dokku-03.cs.ucsb.edu/

Closes: #13 