### PR TITLE
Added UCSBOrganizationTable Component 

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,0 +1,31 @@
+const ucsbOrganizationFixtures = {
+  oneOrganization: {
+    orgCode: "ARTS",
+    orgTranslationShort: "Arts",
+    orgTranslation: "College of Letters and Science - Arts and Humanities",
+    inactive: false,
+  },
+
+  threeOrganizations: [
+    {
+      orgCode: "ARTS",
+      orgTranslationShort: "Arts",
+      orgTranslation: "College of Letters and Science - Arts and Humanities",
+      inactive: false,
+    },
+    {
+      orgCode: "ENGR",
+      orgTranslationShort: "Engineering",
+      orgTranslation: "College of Engineering",
+      inactive: false,
+    },
+    {
+      orgCode: "EXT",
+      orgTranslationShort: "Extension",
+      orgTranslation: "UCSB Extension",
+      inactive: true,
+    },
+  ],
+};
+
+export { ucsbOrganizationFixtures };

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.jsx
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+import { toast } from "react-toastify";
+
+function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/UCSBOrganization",
+    method: "DELETE",
+    params: {
+      orgCode: cell.row.original.orgCode,
+    },
+  };
+}
+
+export default function UCSBOrganizationTable({
+  organizations,
+  currentUser,
+  testIdPrefix = "UCSBOrganizationTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/ucsborganization/edit/${cell.row.original.orgCode}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/UCSBOrganization/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "Org Code",
+      accessorKey: "orgCode",
+    },
+    {
+      header: "Org Translation Short",
+      accessorKey: "orgTranslationShort",
+    },
+    {
+      header: "Org Translation",
+      accessorKey: "orgTranslation",
+    },
+    {
+      header: "Inactive",
+      accessorKey: "inactive",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return (
+    <OurTable data={organizations} columns={columns} testid={testIdPrefix} />
+  );
+}

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.jsx
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/UCSBOrganization/UCSBOrganizationTable",
+  component: UCSBOrganizationTable,
+};
+
+const Template = (args) => {
+  return <UCSBOrganizationTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  organizations: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  organizations: ucsbOrganizationFixtures.threeOrganizations,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  organizations: ucsbOrganizationFixtures.threeOrganizations,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/UCSBOrganization", () => {
+      return HttpResponse.json(
+        { message: "UCSBOrganization deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.jsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from "react-router";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "tests/testutils/mockConsole";
 
 const mockedNavigate = vi.fn();
 vi.mock("react-router", async () => {
@@ -13,6 +14,15 @@ vi.mock("react-router", async () => {
   return {
     ...originalModule,
     useNavigate: () => mockedNavigate,
+  };
+});
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
   };
 });
 
@@ -32,6 +42,10 @@ describe("UCSBOrganizationTable tests", () => {
     "inactive",
   ];
   const testId = "UCSBOrganizationTable";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   test("renders empty table correctly", () => {
     const currentUser = currentUserFixtures.adminUser;
@@ -177,6 +191,7 @@ describe("UCSBOrganizationTable tests", () => {
 
   test("Delete button calls delete callback", async () => {
     const currentUser = currentUserFixtures.adminUser;
+    const restoreConsole = mockConsole();
 
     const axiosMock = new AxiosMockAdapter(axios);
     axiosMock
@@ -207,5 +222,15 @@ describe("UCSBOrganizationTable tests", () => {
 
     await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
     expect(axiosMock.history.delete[0].params).toEqual({ orgCode: "ARTS" });
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith({
+        message: "UCSBOrganization deleted",
+      }),
+    );
+    expect(console.log).toHaveBeenCalledWith({
+      message: "UCSBOrganization deleted",
+    });
+
+    restoreConsole();
   });
 });

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.jsx
@@ -1,0 +1,211 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("UCSBOrganizationTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Org Code",
+    "Org Translation Short",
+    "Org Translation",
+    "Inactive",
+  ];
+  const expectedFields = [
+    "orgCode",
+    "orgTranslationShort",
+    "orgTranslation",
+    "inactive",
+  ];
+  const testId = "UCSBOrganizationTable";
+
+  test("renders empty table correctly", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable
+            organizations={ucsbOrganizationFixtures.threeOrganizations}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("ARTS");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`),
+    ).toHaveTextContent("Arts");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-orgCode`),
+    ).toHaveTextContent("ENGR");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-orgTranslationShort`),
+    ).toHaveTextContent("Engineering");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers and content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable
+            organizations={ucsbOrganizationFixtures.threeOrganizations}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("ARTS");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-orgCode`),
+    ).toHaveTextContent("ENGR");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable
+            organizations={ucsbOrganizationFixtures.threeOrganizations}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("ARTS");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        "/ucsborganization/edit/ARTS",
+      ),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/UCSBOrganization")
+      .reply(200, { message: "UCSBOrganization deleted" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable
+            organizations={ucsbOrganizationFixtures.threeOrganizations}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("ARTS");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ orgCode: "ARTS" });
+  });
+});


### PR DESCRIPTION
This PR adds the `UCSBOrganizationTable` component for displaying UCSBOrganization records.

The table displays all fields from the UCSBOrganization object:
- Org Code
- Org Translation Short
- Org Translation
- Inactive

It supports role-based rendering:
- ordinary users can view the table data
- admin users can see Edit and Delete buttons

<img width="2382" height="446" alt="image" src="https://github.com/user-attachments/assets/b523f8ad-c581-4a97-b713-b711659a3739" />


Closes #14 
Link to Deployment: https://team02-powertriceps-dev.dokku-03.cs.ucsb.edu
Link to storyboard:  https://ucsb-cs156-s26.github.io/team02-s26-03/prs/72/chromatic