### PR TITLE
Add UCSBOrganization create page

### DIFF
--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
@@ -1,11 +1,49 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBOrganizationCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (ucsbOrganization) => ({
+    url: "/api/UCSBOrganization/post",
+    method: "POST",
+    params: {
+      orgCode: ucsbOrganization.orgCode,
+      orgTranslationShort: ucsbOrganization.orgTranslationShort,
+      orgTranslation: ucsbOrganization.orgTranslation,
+      inactive: ucsbOrganization.inactive,
+    },
+  });
+
+  const onSuccess = (ucsbOrganization) => {
+    toast(
+      `New UCSBOrganization Created - orgCode: ${ucsbOrganization.orgCode}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/UCSBOrganization/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganization" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>UCSBOrganization Create page not yet implemented</h1>
+        <h1>Create New UCSBOrganization</h1>
+        <UCSBOrganizationForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationCreatePage",
+  component: UCSBOrganizationCreatePage,
+};
+
+const Template = () => <UCSBOrganizationCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/UCSBOrganization/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
@@ -7,7 +7,27 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("UCSBOrganizationCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
@@ -23,9 +43,39 @@ describe("UCSBOrganizationCreatePage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     setupUserOnly();
+  });
+
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByText("Create New UCSBOrganization"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("UCSBOrganizationForm-orgCode"),
+    ).toBeInTheDocument();
+  });
+
+  test("on submit, makes request to backend, and redirects to /ucsborganization", async () => {
+    const queryClient = new QueryClient();
+    const ucsbOrganization = {
+      orgCode: "LIBR",
+      orgTranslationShort: "Library",
+      orgTranslation: "UCSB Library",
+      inactive: true,
+    };
+
+    axiosMock.onPost("/api/UCSBOrganization/post").reply(202, ucsbOrganization);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -35,9 +85,63 @@ describe("UCSBOrganizationCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("UCSBOrganization Create page not yet implemented");
+    await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+    fireEvent.change(screen.getByTestId("UCSBOrganizationForm-orgCode"), {
+      target: { value: "LIBR" },
+    });
+    fireEvent.change(
+      screen.getByTestId("UCSBOrganizationForm-orgTranslationShort"),
+      {
+        target: { value: "Library" },
+      },
+    );
+    fireEvent.change(
+      screen.getByTestId("UCSBOrganizationForm-orgTranslation"),
+      {
+        target: { value: "UCSB Library" },
+      },
+    );
+    fireEvent.click(screen.getByTestId("UCSBOrganizationForm-inactive"));
+    fireEvent.click(screen.getByTestId("UCSBOrganizationForm-submit"));
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      orgCode: "LIBR",
+      orgTranslationShort: "Library",
+      orgTranslation: "UCSB Library",
+      inactive: true,
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New UCSBOrganization Created - orgCode: LIBR",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
+  });
+
+  test("on invalid submit, shows errors and does not call backend", async () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(await screen.findByTestId("UCSBOrganizationForm-submit"));
+
     expect(
-      screen.getByText("UCSBOrganization Create page not yet implemented"),
+      await screen.findByText("Org Code is required."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("Org Translation Short is required."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Org Translation is required."),
+    ).toBeInTheDocument();
+    expect(axiosMock.history.post.length).toBe(0);
   });
 });


### PR DESCRIPTION
This PR implements the create page for UCSBOrganization.

Changes:
- Replaced the temporary UCSBOrganization create placeholder with a real create page.
- Added `UCSBOrganizationForm` to the create page.
- Submits valid form data to `POST /api/UCSBOrganization/post`.
- Redirects to `/ucsborganization` after a successful create.
- Displays validation errors when required fields are missing.
- Added tests for rendering, successful submit, redirect behavior, and invalid submit behavior.
- Added a Storybook entry for the create page.

<img width="2986" height="1164" alt="image" src="https://github.com/user-attachments/assets/bcb5863a-2db3-4770-87ad-bd01f6747620" />

With validation

<img width="3002" height="1350" alt="image" src="https://github.com/user-attachments/assets/bf36911c-f400-47ad-b335-a85db46b5ce6" />

Link to storyboard: https://ucsb-cs156-s26.github.io/team02-s26-03/prs/74/chromatic
Link to Deployment: https://team02-powertriceps-dev.dokku-03.cs.ucsb.edu/
Closes #16 




