### PR TITLE
Added edit page to UCSBOrganization

### DIFF
--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
@@ -1,11 +1,49 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBOrganizationCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (ucsbOrganization) => ({
+    url: "/api/UCSBOrganization/post",
+    method: "POST",
+    params: {
+      orgCode: ucsbOrganization.orgCode,
+      orgTranslationShort: ucsbOrganization.orgTranslationShort,
+      orgTranslation: ucsbOrganization.orgTranslation,
+      inactive: ucsbOrganization.inactive,
+    },
+  });
+
+  const onSuccess = (ucsbOrganization) => {
+    toast(
+      `New UCSBOrganization Created - orgCode: ${ucsbOrganization.orgCode}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/UCSBOrganization/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganization" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>UCSBOrganization Create page not yet implemented</h1>
+        <h1>Create New UCSBOrganization</h1>
+        <UCSBOrganizationForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
@@ -1,11 +1,75 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBOrganizationEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: ucsbOrganization,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/UCSBOrganization?orgCode=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: "/api/UCSBOrganization",
+      params: {
+        orgCode: id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (ucsbOrganization) => ({
+    url: "/api/UCSBOrganization",
+    method: "PUT",
+    params: {
+      orgCode: id,
+    },
+    data: {
+      orgTranslationShort: ucsbOrganization.orgTranslationShort,
+      orgTranslation: ucsbOrganization.orgTranslation,
+      inactive: ucsbOrganization.inactive,
+    },
+  });
+
+  const onSuccess = (ucsbOrganization) => {
+    toast(`UCSBOrganization Updated - orgCode: ${ucsbOrganization.orgCode}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/UCSBOrganization?orgCode=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganization" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>UCSBOrganization Edit page not yet implemented</h1>
+        <h1>Edit UCSBOrganization</h1>
+        {ucsbOrganization && (
+          <UCSBOrganizationForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={ucsbOrganization}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx
@@ -1,17 +1,47 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { useBackend } from "main/utils/useBackend";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function UCSBOrganizationIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: organizations,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/UCSBOrganization/all"],
+    { method: "GET", url: "/api/UCSBOrganization/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/ucsborganization/create"
+          style={{ float: "right" }}
+        >
+          Create UCSBOrganization
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>UCSBOrganization Index page not yet implemented</h1>
-        <p>
-          <a href="/ucsborganization/create">Create</a>
-        </p>
-        <p>
-          <a href="/ucsborganization/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>UCSBOrganization</h1>
+        <UCSBOrganizationTable
+          organizations={organizations}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationCreatePage",
+  component: UCSBOrganizationCreatePage,
+};
+
+const Template = () => <UCSBOrganizationCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/UCSBOrganization/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationEditPage",
+  component: UCSBOrganizationEditPage,
+};
+
+const Template = () => <UCSBOrganizationEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/UCSBOrganization", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.oneOrganization, {
+        status: 200,
+      });
+    }),
+    http.put("/api/UCSBOrganization", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationIndexPage.stories.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationIndexPage",
+  component: UCSBOrganizationIndexPage,
+};
+
+const Template = () => <UCSBOrganizationIndexPage />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/UCSBOrganization/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/UCSBOrganization/all", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.threeOrganizations);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/UCSBOrganization/all", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.threeOrganizations);
+    }),
+    http.delete("/api/UCSBOrganization", () => {
+      return HttpResponse.json(
+        { message: "UCSBOrganization deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
@@ -7,7 +7,27 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("UCSBOrganizationCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
@@ -23,9 +43,39 @@ describe("UCSBOrganizationCreatePage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     setupUserOnly();
+  });
+
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByText("Create New UCSBOrganization"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("UCSBOrganizationForm-orgCode"),
+    ).toBeInTheDocument();
+  });
+
+  test("on submit, makes request to backend, and redirects to /ucsborganization", async () => {
+    const queryClient = new QueryClient();
+    const ucsbOrganization = {
+      orgCode: "LIBR",
+      orgTranslationShort: "Library",
+      orgTranslation: "UCSB Library",
+      inactive: true,
+    };
+
+    axiosMock.onPost("/api/UCSBOrganization/post").reply(202, ucsbOrganization);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -35,9 +85,63 @@ describe("UCSBOrganizationCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("UCSBOrganization Create page not yet implemented");
+    await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+    fireEvent.change(screen.getByTestId("UCSBOrganizationForm-orgCode"), {
+      target: { value: "LIBR" },
+    });
+    fireEvent.change(
+      screen.getByTestId("UCSBOrganizationForm-orgTranslationShort"),
+      {
+        target: { value: "Library" },
+      },
+    );
+    fireEvent.change(
+      screen.getByTestId("UCSBOrganizationForm-orgTranslation"),
+      {
+        target: { value: "UCSB Library" },
+      },
+    );
+    fireEvent.click(screen.getByTestId("UCSBOrganizationForm-inactive"));
+    fireEvent.click(screen.getByTestId("UCSBOrganizationForm-submit"));
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      orgCode: "LIBR",
+      orgTranslationShort: "Library",
+      orgTranslation: "UCSB Library",
+      inactive: true,
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New UCSBOrganization Created - orgCode: LIBR",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
+  });
+
+  test("on invalid submit, shows errors and does not call backend", async () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(await screen.findByTestId("UCSBOrganizationForm-submit"));
+
     expect(
-      screen.getByText("UCSBOrganization Create page not yet implemented"),
+      await screen.findByText("Org Code is required."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("Org Translation Short is required."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Org Translation is required."),
+    ).toBeInTheDocument();
+    expect(axiosMock.history.post.length).toBe(0);
   });
 });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
@@ -1,43 +1,249 @@
-import { render, screen } from "@testing-library/react";
-import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+import mockConsole from "tests/testutils/mockConsole";
 
-describe("UCSBOrganizationEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
   };
+});
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+const mockNavigate = vi.fn();
+const mockUseNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: "ARTS",
+    })),
+    useNavigate: () => mockUseNavigate,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <UCSBOrganizationEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+let axiosMock;
+describe("UCSBOrganizationEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/UCSBOrganization", { params: { orgCode: "ARTS" } })
+        .timeout();
+    });
 
-    await screen.findByText("UCSBOrganization Edit page not yet implemented");
-    expect(
-      screen.getByText("UCSBOrganization Edit page not yet implemented"),
-    ).toBeInTheDocument();
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      mockUseNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    test("renders header but form is not present", async () => {
+      const queryClient = new QueryClient();
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByText("Edit UCSBOrganization");
+      expect(
+        screen.queryByTestId("UCSBOrganizationForm-orgCode"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/UCSBOrganization", { params: { orgCode: "ARTS" } })
+        .reply(200, ucsbOrganizationFixtures.oneOrganization);
+      axiosMock.onPut("/api/UCSBOrganization").reply(200, {
+        orgCode: "ARTS",
+        orgTranslationShort: "Updated Arts",
+        orgTranslation: "Updated Arts Organization",
+        inactive: true,
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      mockUseNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    test("is populated with the data provided", async () => {
+      const queryClient = new QueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+      const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
+      const orgTranslationShortField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslationShort",
+      );
+      const orgTranslationField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslation",
+      );
+      const inactiveField = screen.getByTestId("UCSBOrganizationForm-inactive");
+      const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+      expect(orgCodeField).toBeInTheDocument();
+      expect(orgCodeField).toHaveValue("ARTS");
+      expect(orgCodeField).toBeDisabled();
+      expect(orgTranslationShortField).toHaveValue("Arts");
+      expect(orgTranslationField).toHaveValue(
+        "College of Letters and Science - Arts and Humanities",
+      );
+      expect(inactiveField).not.toBeChecked();
+      expect(submitButton).toHaveTextContent("Update");
+    });
+
+    test("changes when you click Update", async () => {
+      const queryClient = new QueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+      const orgTranslationShortField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslationShort",
+      );
+      const orgTranslationField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslation",
+      );
+      const inactiveField = screen.getByTestId("UCSBOrganizationForm-inactive");
+      const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+      fireEvent.change(orgTranslationShortField, {
+        target: { value: "Updated Arts" },
+      });
+      fireEvent.change(orgTranslationField, {
+        target: { value: "Updated Arts Organization" },
+      });
+      fireEvent.click(inactiveField);
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "UCSBOrganization Updated - orgCode: ARTS",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ orgCode: "ARTS" });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          orgTranslationShort: "Updated Arts",
+          orgTranslation: "Updated Arts Organization",
+          inactive: true,
+        }),
+      );
+    });
+
+    test("on invalid submit, shows errors and does not call backend", async () => {
+      const queryClient = new QueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+      fireEvent.change(
+        screen.getByTestId("UCSBOrganizationForm-orgTranslationShort"),
+        {
+          target: { value: "" },
+        },
+      );
+      fireEvent.change(
+        screen.getByTestId("UCSBOrganizationForm-orgTranslation"),
+        {
+          target: { value: "" },
+        },
+      );
+      fireEvent.click(screen.getByTestId("UCSBOrganizationForm-submit"));
+
+      expect(
+        await screen.findByText("Org Translation Short is required."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Org Translation is required."),
+      ).toBeInTheDocument();
+      expect(axiosMock.history.put.length).toBe(0);
+    });
+
+    test("cancel routes back to the previous page", async () => {
+      const queryClient = new QueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      fireEvent.click(await screen.findByTestId("UCSBOrganizationForm-cancel"));
+
+      await waitFor(() => expect(mockUseNavigate).toHaveBeenCalledWith(-1));
+    });
   });
 });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx
@@ -1,15 +1,28 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import mockConsole from "tests/testutils/mockConsole";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
 describe("UCSBOrganizationIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "UCSBOrganizationTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,9 +35,25 @@ describe("UCSBOrganizationIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("renders with Create button for admin user", async () => {
+    const queryClient = new QueryClient();
+    setupAdminUser();
+    axiosMock.onGet("/api/UCSBOrganization/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -34,18 +63,135 @@ describe("UCSBOrganizationIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("UCSBOrganization Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText("Create UCSBOrganization")).toBeInTheDocument();
+    });
+    const button = screen.getByText("Create UCSBOrganization");
+    expect(button).toHaveAttribute("href", "/ucsborganization/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three organizations correctly for regular user", async () => {
+    const queryClient = new QueryClient();
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/UCSBOrganization/all")
+      .reply(200, ucsbOrganizationFixtures.threeOrganizations);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+      ).toHaveTextContent("ARTS");
+    });
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-orgCode`),
+    ).toHaveTextContent("ENGR");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-orgCode`),
+    ).toHaveTextContent("EXT");
 
     expect(
-      screen.getByText("UCSBOrganization Index page not yet implemented"),
+      screen.queryByText("Create UCSBOrganization"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("College of Letters and Science - Arts and Humanities"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toHaveAttribute(
-      "href",
-      "/ucsborganization/create",
+    expect(screen.getByText("College of Engineering")).toBeInTheDocument();
+    expect(screen.getByText("UCSB Extension")).toBeInTheDocument();
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    const queryClient = new QueryClient();
+    setupUserOnly();
+    axiosMock.onGet("/api/UCSBOrganization/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
-    expect(screen.getByText("Edit")).toHaveAttribute(
-      "href",
-      "/ucsborganization/edit/1",
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/UCSBOrganization/all",
     );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    const queryClient = new QueryClient();
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/UCSBOrganization/all")
+      .reply(200, ucsbOrganizationFixtures.threeOrganizations);
+    axiosMock
+      .onDelete("/api/UCSBOrganization")
+      .reply(200, "UCSBOrganization with orgCode ARTS was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("ARTS");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith(
+        "UCSBOrganization with orgCode ARTS was deleted",
+      );
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/UCSBOrganization");
+    expect(axiosMock.history.delete[0].params).toEqual({ orgCode: "ARTS" });
   });
 });


### PR DESCRIPTION
This PR completes the UCSBOrganization frontend CRUD pages.

Changes:
- Implements the UCSBOrganization create page.
- Implements the UCSBOrganization index page.
- Implements the UCSBOrganization edit page.
- Uses `UCSBOrganizationForm` for create and edit workflows.
- Uses `UCSBOrganizationTable` on the index page.
- Fetches records from `GET /api/UCSBOrganization/all`.
- Creates records with `POST /api/UCSBOrganization/post`.
- Loads individual records with `GET /api/UCSBOrganization?orgCode=<orgCode>`.
- Updates records with `PUT /api/UCSBOrganization?orgCode=<orgCode>`.
- Deletes records with `DELETE /api/UCSBOrganization?orgCode=<orgCode>`.
- Shows create/edit/delete actions only for admin users.
- Allows regular users to view UCSBOrganization table data without admin actions.
- Adds tests and Storybook stories for create, index, and edit pages.


<img width="2896" height="1122" alt="image" src="https://github.com/user-attachments/assets/47c7b484-c79f-4c6a-a722-78fae0893fdc" />


<img width="2992" height="1398" alt="image" src="https://github.com/user-attachments/assets/e579c0b7-ba1c-4b56-88f0-8abdf14bdcf8" />




Link to Storyboard: https://ucsb-cs156-s26.github.io/team02-s26-03/prs/76/chromatic
Link to Deployment: https://team02-powertriceps-dev.dokku-03.cs.ucsb.edu/
Closes #18 
