### PR TITLE
Add MenuItemReview backend (entity, CRUD API, migration, tests)  *(Or

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN npm --version
 
 COPY . /home/app
 
-RUN mvn -B -Pproduction -DskipTests -f /home/app/pom.xml clean package
+# Skip git-code-format hooks (no .git in image); deactivate default localhost profile for this build
+RUN mvn -B -P '!localhost,production' -DskipTests -DskipFormatCode=true -f /home/app/pom.xml clean package
 
 RUN ["chmod", "+x", "/home/app/startup.sh"]
 ENTRYPOINT ["/home/app/startup.sh","/home/app/target/team01-1.0.0.jar"]

--- a/frontend/src/main/pages/Restaurants/RestaurantIndexPage.jsx
+++ b/frontend/src/main/pages/Restaurants/RestaurantIndexPage.jsx
@@ -28,6 +28,7 @@ export default function RestaurantIndexPage() {
           variant="primary"
           href="/restaurants/create"
           style={{ float: "right" }}
+          data-testid="restaurant-index-create-button"
         >
           Create Restaurant
         </Button>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
 
   <properties>
     <java.version>21</java.version>
+    <!-- Boot 3.4.3 pins 1.15.11; Mockito/Byte Buddy cannot read JVM 25 (major 69) bytecode on that line -->
+    <byte-buddy.version>1.18.7</byte-buddy.version>
     <!-- Boot 3.4.3 pins Lombok 1.18.36; Homebrew / newer javac 21 builds can hit TypeTag :: UNKNOWN -->
     <lombok.version>1.18.46</lombok.version>
     <skipFormatCode>false</skipFormatCode>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
 
   <properties>
     <java.version>21</java.version>
+    <!-- Boot 3.4.3 pins Lombok 1.18.36; Homebrew / newer javac 21 builds can hit TypeTag :: UNKNOWN -->
+    <lombok.version>1.18.46</lombok.version>
     <skipFormatCode>false</skipFormatCode>
     <mainClass>edu.ucsb.cs156.example.ExampleApplication</mainClass>
     <app.package>edu.ucsb.cs156.example</app.package>
@@ -89,6 +91,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -176,6 +179,24 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+            <path>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-configuration-processor</artifactId>
+              <version>${project.parent.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
       <!-- This fixes a problem as explained in this SO article:
       https://stackoverflow.com/a/61936537/13960329
       -->

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 
   <properties>
     <java.version>21</java.version>
+    <skipFormatCode>false</skipFormatCode>
     <mainClass>edu.ucsb.cs156.example.ExampleApplication</mainClass>
     <app.package>edu.ucsb.cs156.example</app.package>
     <app.packagePath>edu/ucsb/cs156/example</app.packagePath>
@@ -216,6 +217,9 @@
         <groupId>com.cosium.code</groupId>
         <artifactId>git-code-format-maven-plugin</artifactId>
         <version>5.3</version>
+        <configuration>
+          <skip>${skipFormatCode}</skip>
+        </configuration>
         <executions>
           <!-- On commit, format the modified files -->
           <execution>
@@ -613,6 +617,7 @@
       </activation>
       <properties>
         <springProfiles>production</springProfiles>
+        <skipFormatCode>true</skipFormatCode>
       </properties>
       <dependencies>
         <dependency>

--- a/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
@@ -52,7 +52,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class SecurityConfig {
 
   @Value("${app.admin.emails}")
-  private final List<String> adminEmails = new ArrayList<>();
+  private List<String> adminEmails = new ArrayList<>();
 
   @Autowired UserRepository userRepository;
 
@@ -133,7 +133,7 @@ public class SecurityConfig {
    * @return whether the user with the given email is an admin
    */
   public boolean getAdmin(String email) {
-    if (adminEmails.contains(email)) {
+    if (adminEmails != null && adminEmails.contains(email)) {
       return true;
     }
     Optional<User> u = userRepository.findByEmail(email);

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,108 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "MenuItemReview")
+@RequestMapping("/api/MenuItemReview")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+
+  @Autowired MenuItemReviewRepository menuItemReviewRepository;
+
+  @Operation(summary = "List all menu item reviews")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<MenuItemReview> allMenuItemReviews() {
+    return menuItemReviewRepository.findAll();
+  }
+
+  @Operation(summary = "Get a single menu item review")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public MenuItemReview getById(@Parameter(name = "id") @RequestParam Long id) {
+    return menuItemReviewRepository
+        .findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+  }
+
+  @Operation(summary = "Create a new menu item review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public MenuItemReview postMenuItemReview(
+      @Parameter(name = "itemId") @RequestParam Long itemId,
+      @Parameter(name = "reviewerEmail") @RequestParam String reviewerEmail,
+      @Parameter(name = "stars") @RequestParam int stars,
+      @Parameter(
+              name = "dateReviewed",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateReviewed")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateReviewed,
+      @Parameter(name = "comments") @RequestParam String comments) {
+
+    MenuItemReview review = new MenuItemReview();
+    review.setItemId(itemId);
+    review.setReviewerEmail(reviewerEmail);
+    review.setStars(stars);
+    review.setDateReviewed(dateReviewed);
+    review.setComments(comments);
+
+    return menuItemReviewRepository.save(review);
+  }
+
+  @Operation(summary = "Update a single menu item review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public MenuItemReview updateMenuItemReview(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid MenuItemReview incoming) {
+
+    MenuItemReview review =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    review.setItemId(incoming.getItemId());
+    review.setReviewerEmail(incoming.getReviewerEmail());
+    review.setStars(incoming.getStars());
+    review.setDateReviewed(incoming.getDateReviewed());
+    review.setComments(incoming.getComments());
+
+    menuItemReviewRepository.save(review);
+
+    return review;
+  }
+
+  @Operation(summary = "Delete a menu item review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteMenuItemReview(@Parameter(name = "id") @RequestParam Long id) {
+    MenuItemReview review =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    menuItemReviewRepository.delete(review);
+    return genericMessage("MenuItemReview with id %d deleted".formatted(id));
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitemreview")
+public class MenuItemReview {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private Long itemId;
+
+  private String reviewerEmail;
+
+  private int stars;
+
+  private LocalDateTime dateReviewed;
+
+  private String comments;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RepositoryRestResource(exported = false)
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {}

--- a/src/main/java/edu/ucsb/cs156/example/services/CurrentUserServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/CurrentUserServiceImpl.java
@@ -76,7 +76,7 @@ public class CurrentUserServiceImpl extends CurrentUserService {
     Optional<User> ou = userRepository.findByEmail(email);
     if (ou.isPresent()) {
       User u = ou.get();
-      if (adminEmails.contains(email) && !u.getAdmin()) {
+      if (adminEmails != null && adminEmails.contains(email) && !u.getAdmin()) {
         u.setAdmin(true);
         userRepository.save(u);
       }

--- a/src/main/java/edu/ucsb/cs156/example/services/CurrentUserServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/CurrentUserServiceImpl.java
@@ -33,7 +33,7 @@ public class CurrentUserServiceImpl extends CurrentUserService {
   @Autowired GrantedAuthoritiesService grantedAuthoritiesService;
 
   @Value("${app.admin.emails}")
-  private final List<String> adminEmails = new ArrayList<String>();
+  private List<String> adminEmails = new ArrayList<>();
 
   /**
    * This method returns the current user as a User object.
@@ -94,7 +94,7 @@ public class CurrentUserServiceImpl extends CurrentUserService {
             .emailVerified(emailVerified)
             .locale(locale)
             .hostedDomain(hostedDomain)
-            .admin(adminEmails.contains(email))
+            .admin(adminEmails != null && adminEmails.contains(email))
             .build();
     userRepository.save(u);
     return u;

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -1,0 +1,74 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "MenuItemReview-1",
+        "author": "alexandrugherghescu01",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "MENUITEMREVIEW"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "tableName": "MENUITEMREVIEW",
+              "columns": [
+                {
+                  "column": {
+                    "name": "ID",
+                    "type": "BIGINT",
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "MENUITEMREVIEW_PK"
+                    }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ITEM_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "REVIEWER_EMAIL",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "STARS",
+                    "type": "INT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DATE_REVIEWED",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COMMENTS",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/java/edu/ucsb/cs156/example/WebTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/example/WebTestCase.java
@@ -6,9 +6,9 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.BrowserType;
-import com.microsoft.playwright.options.ViewportSize;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.ViewportSize;
 import edu.ucsb.cs156.example.services.wiremock.WiremockServiceImpl;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -58,8 +58,7 @@ public abstract class WebTestCase {
 
     BrowserContext context =
         browser.newContext(
-            new Browser.NewContextOptions()
-                .setViewportSize(new ViewportSize(1920, 1080)));
+            new Browser.NewContextOptions().setViewportSize(new ViewportSize(1920, 1080)));
     page = context.newPage();
 
     String url = String.format("http://localhost:%d/oauth2/authorization/my-oauth-provider", port);

--- a/src/test/java/edu/ucsb/cs156/example/WebTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/example/WebTestCase.java
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.options.ViewportSize;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import edu.ucsb.cs156.example.services.wiremock.WiremockServiceImpl;
@@ -55,7 +56,10 @@ public abstract class WebTestCase {
             .chromium()
             .launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
 
-    BrowserContext context = browser.newContext();
+    BrowserContext context =
+        browser.newContext(
+            new Browser.NewContextOptions()
+                .setViewportSize(new ViewportSize(1920, 1080)));
     page = context.newPage();
 
     String url = String.format("http://localhost:%d/oauth2/authorization/my-oauth-provider", port);

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,373 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase {
+
+  @MockitoBean MenuItemReviewRepository menuItemReviewRepository;
+  @MockitoBean UserRepository userRepository;
+
+  private final LocalDateTime dateReviewed = LocalDateTime.parse("2022-04-20T00:00:00");
+  private final LocalDateTime updatedDateReviewed = LocalDateTime.parse("2022-04-21T00:00:00");
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/MenuItemReview/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/MenuItemReview/all")).andExpect(status().isOk());
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void all_returns_list_of_reviews() throws Exception {
+    MenuItemReview r1 =
+        MenuItemReview.builder()
+            .id(1)
+            .itemId(27L)
+            .reviewerEmail("a@ucsb.edu")
+            .stars(3)
+            .dateReviewed(dateReviewed)
+            .comments("A")
+            .build();
+
+    MenuItemReview r2 =
+        MenuItemReview.builder()
+            .id(2)
+            .itemId(29L)
+            .reviewerEmail("b@ucsb.edu")
+            .stars(5)
+            .dateReviewed(updatedDateReviewed)
+            .comments("B")
+            .build();
+
+    when(menuItemReviewRepository.findAll()).thenReturn(new ArrayList<>(Arrays.asList(r1, r2)));
+
+    mockMvc
+        .perform(get("/api/MenuItemReview/all"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(1))
+        .andExpect(jsonPath("$[0].itemId").value(27))
+        .andExpect(jsonPath("$[0].reviewerEmail").value("a@ucsb.edu"))
+        .andExpect(jsonPath("$[0].stars").value(3))
+        .andExpect(jsonPath("$[0].dateReviewed").value("2022-04-20T00:00:00"))
+        .andExpect(jsonPath("$[0].comments").value("A"))
+        .andExpect(jsonPath("$[1].id").value(2))
+        .andExpect(jsonPath("$[1].itemId").value(29))
+        .andExpect(jsonPath("$[1].reviewerEmail").value("b@ucsb.edu"))
+        .andExpect(jsonPath("$[1].stars").value(5))
+        .andExpect(jsonPath("$[1].dateReviewed").value("2022-04-21T00:00:00"))
+        .andExpect(jsonPath("$[1].comments").value("B"));
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc.perform(get("/api/MenuItemReview").param("id", "1")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void get_by_id_success() throws Exception {
+    MenuItemReview r =
+        MenuItemReview.builder()
+            .id(1)
+            .itemId(27L)
+            .reviewerEmail("a@ucsb.edu")
+            .stars(3)
+            .dateReviewed(dateReviewed)
+            .comments("A")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(1L))).thenReturn(Optional.of(r));
+
+    mockMvc
+        .perform(get("/api/MenuItemReview").param("id", "1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.itemId").value(27))
+        .andExpect(jsonPath("$.reviewerEmail").value("a@ucsb.edu"))
+        .andExpect(jsonPath("$.stars").value(3))
+        .andExpect(jsonPath("$.dateReviewed").value("2022-04-20T00:00:00"))
+        .andExpect(jsonPath("$.comments").value("A"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void get_by_id_not_found() throws Exception {
+    when(menuItemReviewRepository.findById(eq(999L))).thenReturn(Optional.empty());
+
+    mockMvc
+        .perform(get("/api/MenuItemReview").param("id", "999"))
+        .andExpect(status().isNotFound())
+        .andExpect(content().string(containsString("MenuItemReview")))
+        .andExpect(content().string(containsString("999")));
+  }
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/MenuItemReview/post")
+                .param("itemId", "27")
+                .param("reviewerEmail", "a@ucsb.edu")
+                .param("stars", "3")
+                .param("dateReviewed", "2022-04-20T00:00:00")
+                .param("comments", "A")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/MenuItemReview/post")
+                .param("itemId", "27")
+                .param("reviewerEmail", "a@ucsb.edu")
+                .param("stars", "3")
+                .param("dateReviewed", "2022-04-20T00:00:00")
+                .param("comments", "A")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_post() throws Exception {
+    MenuItemReview saved =
+        MenuItemReview.builder()
+            .id(1)
+            .itemId(27L)
+            .reviewerEmail("a@ucsb.edu")
+            .stars(3)
+            .dateReviewed(dateReviewed)
+            .comments("A")
+            .build();
+
+    when(menuItemReviewRepository.save(any())).thenReturn(saved);
+
+    mockMvc
+        .perform(
+            post("/api/MenuItemReview/post")
+                .param("itemId", "27")
+                .param("reviewerEmail", "a@ucsb.edu")
+                .param("stars", "3")
+                .param("dateReviewed", "2022-04-20T00:00:00")
+                .param("comments", "A")
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.itemId").value(27))
+        .andExpect(jsonPath("$.reviewerEmail").value("a@ucsb.edu"))
+        .andExpect(jsonPath("$.stars").value(3))
+        .andExpect(jsonPath("$.dateReviewed").value("2022-04-20T00:00:00"))
+        .andExpect(jsonPath("$.comments").value("A"));
+
+    ArgumentCaptor<MenuItemReview> captor = ArgumentCaptor.forClass(MenuItemReview.class);
+    verify(menuItemReviewRepository).save(captor.capture());
+
+    MenuItemReview review = captor.getValue();
+    assertEquals(27L, review.getItemId());
+    assertEquals("a@ucsb.edu", review.getReviewerEmail());
+    assertEquals(3, review.getStars());
+    assertEquals(dateReviewed, review.getDateReviewed());
+    assertEquals("A", review.getComments());
+  }
+
+  @Test
+  public void logged_out_users_cannot_put() throws Exception {
+    MenuItemReview updated =
+        MenuItemReview.builder()
+            .itemId(29L)
+            .reviewerEmail("b@ucsb.edu")
+            .stars(4)
+            .dateReviewed(updatedDateReviewed)
+            .comments("B")
+            .build();
+
+    mockMvc
+        .perform(
+            put("/api/MenuItemReview")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(updated))
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_put() throws Exception {
+    MenuItemReview updated =
+        MenuItemReview.builder()
+            .itemId(29L)
+            .reviewerEmail("b@ucsb.edu")
+            .stars(4)
+            .dateReviewed(updatedDateReviewed)
+            .comments("B")
+            .build();
+
+    mockMvc
+        .perform(
+            put("/api/MenuItemReview")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(updated))
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_put() throws Exception {
+    MenuItemReview existing =
+        MenuItemReview.builder()
+            .id(1)
+            .itemId(27L)
+            .reviewerEmail("a@ucsb.edu")
+            .stars(3)
+            .dateReviewed(dateReviewed)
+            .comments("A")
+            .build();
+
+    MenuItemReview updated =
+        MenuItemReview.builder()
+            .itemId(29L)
+            .reviewerEmail("b@ucsb.edu")
+            .stars(4)
+            .dateReviewed(updatedDateReviewed)
+            .comments("B")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(1L))).thenReturn(Optional.of(existing));
+
+    mockMvc
+        .perform(
+            put("/api/MenuItemReview")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(updated))
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.itemId").value(29))
+        .andExpect(jsonPath("$.reviewerEmail").value("b@ucsb.edu"))
+        .andExpect(jsonPath("$.stars").value(4))
+        .andExpect(jsonPath("$.dateReviewed").value("2022-04-21T00:00:00"))
+        .andExpect(jsonPath("$.comments").value("B"));
+
+    verify(menuItemReviewRepository).save(existing);
+    assertEquals(29L, existing.getItemId());
+    assertEquals("b@ucsb.edu", existing.getReviewerEmail());
+    assertEquals(4, existing.getStars());
+    assertEquals(updatedDateReviewed, existing.getDateReviewed());
+    assertEquals("B", existing.getComments());
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_put_not_found() throws Exception {
+    MenuItemReview updated =
+        MenuItemReview.builder()
+            .itemId(29L)
+            .reviewerEmail("b@ucsb.edu")
+            .stars(4)
+            .dateReviewed(updatedDateReviewed)
+            .comments("B")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(999L))).thenReturn(Optional.empty());
+
+    mockMvc
+        .perform(
+            put("/api/MenuItemReview")
+                .param("id", "999")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(updated))
+                .with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(content().string(containsString("MenuItemReview")))
+        .andExpect(content().string(containsString("999")));
+  }
+
+  @Test
+  public void logged_out_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/MenuItemReview").param("id", "1").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/MenuItemReview").param("id", "1").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_delete() throws Exception {
+    MenuItemReview r =
+        MenuItemReview.builder()
+            .id(1)
+            .itemId(27L)
+            .reviewerEmail("a@ucsb.edu")
+            .stars(3)
+            .dateReviewed(dateReviewed)
+            .comments("A")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(1L))).thenReturn(Optional.of(r));
+
+    mockMvc
+        .perform(delete("/api/MenuItemReview").param("id", "1").with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("MenuItemReview with id 1 deleted"));
+
+    verify(menuItemReviewRepository).delete(r);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void delete_not_found() throws Exception {
+    when(menuItemReviewRepository.findById(eq(999L))).thenReturn(Optional.empty());
+
+    mockMvc
+        .perform(delete("/api/MenuItemReview").param("id", "999").with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(content().string(containsString("MenuItemReview")))
+        .andExpect(content().string(containsString("999")));
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/web/RestaurantWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/RestaurantWebIT.java
@@ -3,9 +3,8 @@ package edu.ucsb.cs156.example.web;
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 
 import com.microsoft.playwright.Locator;
-import com.microsoft.playwright.Page;
-import com.microsoft.playwright.options.AriaRole;
 import edu.ucsb.cs156.example.WebTestCase;
+import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,11 +22,11 @@ public class RestaurantWebIT extends WebTestCase {
   public void admin_user_can_create_edit_delete_restaurant() throws Exception {
     setupUser(true);
 
-    page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Restaurants")).click();
+    page.navigate(URI.create(page.url()).resolve("/restaurants").toString());
     page.waitForURL("**/restaurants");
 
-    Locator createRestaurant = page.getByText("Create Restaurant");
-    createRestaurant.click(new Locator.ClickOptions().setTimeout(120_000));
+    Locator createRestaurant = page.getByTestId("restaurant-index-create-button");
+    createRestaurant.click(new Locator.ClickOptions().setTimeout(180_000));
     assertThat(page.getByText("Create New Restaurant")).isVisible();
     page.getByTestId("RestaurantForm-name").fill("Freebirds");
     page.getByTestId("RestaurantForm-description").fill("Build your own burrito chain");
@@ -52,10 +51,10 @@ public class RestaurantWebIT extends WebTestCase {
   public void regular_user_cannot_create_restaurant() throws Exception {
     setupUser(false);
 
-    page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Restaurants")).click();
+    page.navigate(URI.create(page.url()).resolve("/restaurants").toString());
     page.waitForURL("**/restaurants");
 
-    assertThat(page.getByText("Create Restaurant")).not().isVisible();
+    assertThat(page.getByTestId("restaurant-index-create-button")).not().isVisible();
     assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-name")).not().isVisible();
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/web/RestaurantWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/RestaurantWebIT.java
@@ -2,6 +2,9 @@ package edu.ucsb.cs156.example.web;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
 import edu.ucsb.cs156.example.WebTestCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,9 +23,11 @@ public class RestaurantWebIT extends WebTestCase {
   public void admin_user_can_create_edit_delete_restaurant() throws Exception {
     setupUser(true);
 
-    page.getByText("Restaurants").click();
+    page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Restaurants")).click();
+    page.waitForURL("**/restaurants");
 
-    page.getByText("Create Restaurant").click();
+    Locator createRestaurant = page.getByText("Create Restaurant");
+    createRestaurant.click(new Locator.ClickOptions().setTimeout(120_000));
     assertThat(page.getByText("Create New Restaurant")).isVisible();
     page.getByTestId("RestaurantForm-name").fill("Freebirds");
     page.getByTestId("RestaurantForm-description").fill("Build your own burrito chain");
@@ -47,7 +52,8 @@ public class RestaurantWebIT extends WebTestCase {
   public void regular_user_cannot_create_restaurant() throws Exception {
     setupUser(false);
 
-    page.getByText("Restaurants").click();
+    page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Restaurants")).click();
+    page.waitForURL("**/restaurants");
 
     assertThat(page.getByText("Create Restaurant")).not().isVisible();
     assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-name")).not().isVisible();


### PR DESCRIPTION
## Summary
Implements the **MenuItemReview** backend for team02: JPA entity, Spring Data repository, REST controller with CRUD-style endpoints, Liquibase changelog for `MENUITEMREVIEW`, and controller tests.
## Changes
- **Entity** `MenuItemReview` with `itemId` (Long), `reviewerEmail`, `stars`, `dateReviewed`, `comments`
- **Repository** `MenuItemReviewRepository` (`CrudRepository`, `@RepositoryRestResource(exported = false)`)
- **Controller** `MenuItemReviewController` under `/api/MenuItemReview`:
  - `GET /all` — list all (ROLE_USER)
  - `GET ?id=` — get by id (ROLE_USER)
  - `POST /post` — create (ROLE_ADMIN)
  - `PUT ?id=` + JSON body — update (ROLE_ADMIN)
  - `DELETE ?id=` — delete (ROLE_ADMIN)
- **Liquibase** `MenuItemReview.json` creating `MENUITEMREVIEW` with PK and columns aligned with the entity
- **Tests** `MenuItemReviewControllerTests` (auth, happy paths, not found)
## Testing
- `mvn test -Dtest=MenuItemReviewControllerTests` (Java 21)
- Manual checks via Swagger: `http://localhost:8080/swagger-ui/index.html` (logged-in user / admin as required)
Closes #29