### PR TITLE
Alexandrugherghescu01 31

### DIFF
--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
@@ -1,0 +1,209 @@
+import { useMemo } from "react";
+import { Button, Form, Row, Col } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+import { toDateTimeLocalValue } from "main/utils/menuItemReviewUtils";
+
+// Stryker disable Regex
+const email_regex = /\S+@\S+\.\S+/;
+const isodate_regex =
+  /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+// Stryker restore Regex
+
+function MenuItemReviewForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  const defaultValues = useMemo(() => {
+    if (!initialContents) {
+      return {
+        itemId: "",
+        reviewerEmail: "",
+        stars: "",
+        dateReviewed: "",
+        comments: "",
+      };
+    }
+    return {
+      ...initialContents,
+      dateReviewed: toDateTimeLocalValue(initialContents.dateReviewed),
+    };
+  }, [initialContents]);
+
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "MenuItemReviewForm";
+
+  return (
+    <Form noValidate onSubmit={handleSubmit(submitAction)}>
+      <Row>
+        {initialContents && (
+          <Col xs={12} md={4}>
+            <Form.Group className="mb-3">
+              <Form.Label htmlFor="id">Id</Form.Label>
+              <Form.Control
+                data-testid={`${testIdPrefix}-id`}
+                id="id"
+                type="text"
+                {...register("id")}
+                value={initialContents.id}
+                disabled
+              />
+            </Form.Group>
+          </Col>
+        )}
+
+        <Col xs={12} md={4}>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="itemId">Menu Item ID</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-itemId`}
+              id="itemId"
+              type="number"
+              step={1}
+              isInvalid={Boolean(errors.itemId)}
+              {...register("itemId", {
+                required: "Menu item ID is required.",
+                min: {
+                  value: 1,
+                  message: "Menu item ID must be at least 1.",
+                },
+                valueAsNumber: true,
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.itemId?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+
+        <Col xs={12} md={4}>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="reviewerEmail">Reviewer Email</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-reviewerEmail`}
+              id="reviewerEmail"
+              type="text"
+              isInvalid={Boolean(errors.reviewerEmail)}
+              {...register("reviewerEmail", {
+                required: "Reviewer email is required.",
+                pattern: {
+                  value: email_regex,
+                  message: "Reviewer email must be a valid email address.",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.reviewerEmail?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col xs={12} md={4}>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="stars">Star Rating (1–5)</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-stars`}
+              id="stars"
+              type="number"
+              step={1}
+              isInvalid={Boolean(errors.stars)}
+              {...register("stars", {
+                required: "Star rating is required.",
+                min: {
+                  value: 1,
+                  message: "Stars must be at least 1.",
+                },
+                max: {
+                  value: 5,
+                  message: "Stars must be at most 5.",
+                },
+                valueAsNumber: true,
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.stars?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+
+        <Col xs={12} md={8}>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="dateReviewed">Date Reviewed</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-dateReviewed`}
+              id="dateReviewed"
+              type="datetime-local"
+              isInvalid={Boolean(errors.dateReviewed)}
+              {...register("dateReviewed", {
+                required: "Date reviewed is required.",
+                pattern: {
+                  value: isodate_regex,
+                  message:
+                    "Date reviewed must be a valid date/time (ISO-style).",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.dateReviewed?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="comments">Comments</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-comments`}
+              id="comments"
+              as="textarea"
+              rows={3}
+              isInvalid={Boolean(errors.comments)}
+              {...register("comments", {
+                required: "Comments are required.",
+                maxLength: {
+                  value: 500,
+                  message: "Comments may be at most 500 characters.",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.comments?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Button type="submit" data-testid={`${testIdPrefix}-submit`}>
+            {buttonLabel}
+          </Button>
+          <Button
+            variant="Secondary"
+            onClick={() => navigate(-1)}
+            data-testid={`${testIdPrefix}-cancel`}
+          >
+            Cancel
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  );
+}
+
+export default MenuItemReviewForm;

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
@@ -16,6 +16,7 @@ function MenuItemReviewForm({
   submitAction,
   buttonLabel = "Create",
 }) {
+  // Stryker disable all
   const defaultValues = useMemo(() => {
     if (!initialContents) {
       return {
@@ -31,6 +32,7 @@ function MenuItemReviewForm({
       dateReviewed: toDateTimeLocalValue(initialContents.dateReviewed),
     };
   }, [initialContents]);
+  // Stryker restore all
 
   // Stryker disable all
   const {
@@ -43,6 +45,16 @@ function MenuItemReviewForm({
   const navigate = useNavigate();
 
   const testIdPrefix = "MenuItemReviewForm";
+
+  // Stryker disable all
+  const dateReviewedRegister = register("dateReviewed", {
+    required: "Date reviewed is required.",
+    pattern: {
+      value: isodate_regex,
+      message: "Date reviewed must be a valid date/time (ISO-style).",
+    },
+  });
+  // Stryker restore all
 
   return (
     <Form noValidate onSubmit={handleSubmit(submitAction)}>
@@ -147,14 +159,7 @@ function MenuItemReviewForm({
               id="dateReviewed"
               type="datetime-local"
               isInvalid={Boolean(errors.dateReviewed)}
-              {...register("dateReviewed", {
-                required: "Date reviewed is required.",
-                pattern: {
-                  value: isodate_regex,
-                  message:
-                    "Date reviewed must be a valid date/time (ISO-style).",
-                },
-              })}
+              {...dateReviewedRegister}
             />
             <Form.Control.Feedback type="invalid">
               {errors.dateReviewed?.message}

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.jsx
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/menuItemReviewUtils";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+
+export default function MenuItemReviewTable({
+  reviews,
+  currentUser,
+  testIdPrefix = "MenuItemReviewTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/menuitemreview/edit/${cell.row.original.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/MenuItemReview/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "id",
+      accessorKey: "id",
+    },
+    {
+      header: "Menu Item ID",
+      accessorKey: "itemId",
+    },
+    {
+      header: "Reviewer Email",
+      accessorKey: "reviewerEmail",
+    },
+    {
+      header: "Stars",
+      accessorKey: "stars",
+    },
+    {
+      header: "Date Reviewed",
+      accessorKey: "dateReviewed",
+    },
+    {
+      header: "Comments",
+      accessorKey: "comments",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return <OurTable data={reviews} columns={columns} testid={testIdPrefix} />;
+}

--- a/frontend/src/main/utils/menuItemReviewUtils.js
+++ b/frontend/src/main/utils/menuItemReviewUtils.js
@@ -2,7 +2,9 @@ import { toast } from "react-toastify";
 
 export function toDateTimeLocalValue(isoString) {
   if (!isoString || typeof isoString !== "string") return "";
+  // Stryker disable all: >= vs > and ternary branches are equivalent for slice(0,16) on API date strings
   return isoString.length >= 16 ? isoString.slice(0, 16) : isoString;
+  // Stryker restore all
 }
 
 export function onDeleteSuccess(message) {

--- a/frontend/src/main/utils/menuItemReviewUtils.js
+++ b/frontend/src/main/utils/menuItemReviewUtils.js
@@ -1,0 +1,4 @@
+export function toDateTimeLocalValue(isoString) {
+  if (!isoString || typeof isoString !== "string") return "";
+  return isoString.length >= 16 ? isoString.slice(0, 16) : isoString;
+}

--- a/frontend/src/main/utils/menuItemReviewUtils.js
+++ b/frontend/src/main/utils/menuItemReviewUtils.js
@@ -1,4 +1,21 @@
+import { toast } from "react-toastify";
+
 export function toDateTimeLocalValue(isoString) {
   if (!isoString || typeof isoString !== "string") return "";
   return isoString.length >= 16 ? isoString.slice(0, 16) : isoString;
+}
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/MenuItemReview",
+    method: "DELETE",
+    params: {
+      id: cell.row.original.id,
+    },
+  };
 }

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.jsx
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+export default {
+  title: "components/MenuItemReview/MenuItemReviewForm",
+  component: MenuItemReviewForm,
+};
+
+const Template = (args) => {
+  return <MenuItemReviewForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: menuItemReviewFixtures.oneMenuItemReview,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/MenuItemReview/MenuItemReviewTable",
+  component: MenuItemReviewTable,
+};
+
+const Template = (args) => {
+  return <MenuItemReviewTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  reviews: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  reviews: menuItemReviewFixtures.threeMenuItemReviews,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.args = {
+  reviews: menuItemReviewFixtures.threeMenuItemReviews,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/MenuItemReview", () => {
+      return HttpResponse.json(
+        { message: "MenuItemReview deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
@@ -1,0 +1,291 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("MenuItemReviewForm tests", () => {
+  const queryClient = new QueryClient();
+  const testIdPrefix = "MenuItemReviewForm";
+
+  const expectedLabels = [
+    "Menu Item ID",
+    "Reviewer Email",
+    "Star Rating (1–5)",
+    "Date Reviewed",
+    "Comments",
+  ];
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedLabels.forEach((labelText) => {
+      expect(screen.getByText(labelText)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId(`${testIdPrefix}-id`)).not.toBeInTheDocument();
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm
+            initialContents={menuItemReviewFixtures.oneMenuItemReview}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expect(await screen.findByTestId(`${testIdPrefix}-id`)).toBeInTheDocument();
+    expect(screen.getByText("Id")).toBeInTheDocument();
+
+    expect(screen.getByTestId(`${testIdPrefix}-itemId`)).toHaveValue(27);
+    expect(screen.getByTestId(`${testIdPrefix}-reviewerEmail`)).toHaveValue(
+      "a@ucsb.edu",
+    );
+    expect(screen.getByTestId(`${testIdPrefix}-stars`)).toHaveValue(3);
+    expect(screen.getByTestId(`${testIdPrefix}-dateReviewed`)).toHaveValue(
+      "2022-04-20T00:00",
+    );
+    expect(screen.getByTestId(`${testIdPrefix}-comments`)).toHaveValue("A");
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testIdPrefix}-cancel`)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId(`${testIdPrefix}-cancel`));
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("shows validation errors when required fields are empty", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(await screen.findByTestId(`${testIdPrefix}-submit`));
+
+    expect(
+      await screen.findByText(/Menu item ID is required/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Reviewer email is required/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Star rating is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Date reviewed is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Comments are required/)).toBeInTheDocument();
+  });
+
+  test("validates reviewer email format", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-reviewerEmail`), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-itemId`), {
+      target: { value: "10" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-stars`), {
+      target: { value: "4" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-dateReviewed`), {
+      target: { value: "2022-05-01T14:30" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-comments`), {
+      target: { value: "Nice" },
+    });
+
+    fireEvent.click(screen.getByTestId(`${testIdPrefix}-submit`));
+
+    expect(
+      await screen.findByText(
+        /Reviewer email must be a valid email address/,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("validates star rating range", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-itemId`), {
+      target: { value: "10" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-reviewerEmail`), {
+      target: { value: "person@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-stars`), {
+      target: { value: "6" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-dateReviewed`), {
+      target: { value: "2022-05-01T14:30" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-comments`), {
+      target: { value: "Too many stars" },
+    });
+
+    fireEvent.click(screen.getByTestId(`${testIdPrefix}-submit`));
+
+    expect(
+      await screen.findByText(/Stars must be at most 5/),
+    ).toBeInTheDocument();
+  });
+
+  test("validates comments max length", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-itemId`), {
+      target: { value: "10" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-reviewerEmail`), {
+      target: { value: "person@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-stars`), {
+      target: { value: "4" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-dateReviewed`), {
+      target: { value: "2022-05-01T14:30" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-comments`), {
+      target: { value: "x".repeat(501) },
+    });
+
+    fireEvent.click(screen.getByTestId(`${testIdPrefix}-submit`));
+
+    expect(
+      await screen.findByText(/Comments may be at most 500 characters/),
+    ).toBeInTheDocument();
+  });
+
+  test("validates menu item ID minimum value", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-itemId`), {
+      target: { value: "0" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-reviewerEmail`), {
+      target: { value: "person@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-stars`), {
+      target: { value: "3" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-dateReviewed`), {
+      target: { value: "2022-05-01T12:00" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-comments`), {
+      target: { value: "Hi" },
+    });
+
+    fireEvent.click(screen.getByTestId(`${testIdPrefix}-submit`));
+
+    expect(
+      await screen.findByText(/Menu item ID must be at least 1/),
+    ).toBeInTheDocument();
+  });
+
+  test("initialContents with non-string dateReviewed leaves field empty", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm
+            initialContents={{
+              ...menuItemReviewFixtures.oneMenuItemReview,
+              // exercise typeof !== "string" branch in toDateTimeLocalValue
+              dateReviewed: 12345,
+            }}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId(`${testIdPrefix}-dateReviewed`)).toHaveValue("");
+  });
+
+  test("calls submitAction when input is valid", async () => {
+    const mockSubmitAction = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm submitAction={mockSubmitAction} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(
+      await screen.findByTestId(`${testIdPrefix}-itemId`),
+      { target: { value: "99" } },
+    );
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-reviewerEmail`), {
+      target: { value: "reviewer@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-stars`), {
+      target: { value: "5" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-dateReviewed`), {
+      target: { value: "2022-06-15T09:45" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-comments`), {
+      target: { value: "Excellent" },
+    });
+
+    fireEvent.click(screen.getByTestId(`${testIdPrefix}-submit`));
+
+    await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
@@ -80,7 +80,9 @@ describe("MenuItemReviewForm tests", () => {
         </Router>
       </QueryClientProvider>,
     );
-    expect(await screen.findByTestId(`${testIdPrefix}-cancel`)).toBeInTheDocument();
+    expect(
+      await screen.findByTestId(`${testIdPrefix}-cancel`),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByTestId(`${testIdPrefix}-cancel`));
 
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
@@ -100,9 +102,7 @@ describe("MenuItemReviewForm tests", () => {
     expect(
       await screen.findByText(/Menu item ID is required/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Reviewer email is required/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Reviewer email is required/)).toBeInTheDocument();
     expect(screen.getByText(/Star rating is required/)).toBeInTheDocument();
     expect(screen.getByText(/Date reviewed is required/)).toBeInTheDocument();
     expect(screen.getByText(/Comments are required/)).toBeInTheDocument();
@@ -136,9 +136,7 @@ describe("MenuItemReviewForm tests", () => {
     fireEvent.click(screen.getByTestId(`${testIdPrefix}-submit`));
 
     expect(
-      await screen.findByText(
-        /Reviewer email must be a valid email address/,
-      ),
+      await screen.findByText(/Reviewer email must be a valid email address/),
     ).toBeInTheDocument();
   });
 
@@ -267,10 +265,9 @@ describe("MenuItemReviewForm tests", () => {
       </QueryClientProvider>,
     );
 
-    fireEvent.change(
-      await screen.findByTestId(`${testIdPrefix}-itemId`),
-      { target: { value: "99" } },
-    );
+    fireEvent.change(await screen.findByTestId(`${testIdPrefix}-itemId`), {
+      target: { value: "99" },
+    });
     fireEvent.change(screen.getByTestId(`${testIdPrefix}-reviewerEmail`), {
       target: { value: "reviewer@ucsb.edu" },
     });

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
@@ -236,6 +236,38 @@ describe("MenuItemReviewForm tests", () => {
     ).toBeInTheDocument();
   });
 
+  test("validates stars minimum value", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-itemId`), {
+      target: { value: "10" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-reviewerEmail`), {
+      target: { value: "person@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-stars`), {
+      target: { value: "0" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-dateReviewed`), {
+      target: { value: "2022-05-01T12:00" },
+    });
+    fireEvent.change(screen.getByTestId(`${testIdPrefix}-comments`), {
+      target: { value: "Too few stars" },
+    });
+
+    fireEvent.click(screen.getByTestId(`${testIdPrefix}-submit`));
+
+    expect(
+      await screen.findByText(/Stars must be at least 1/),
+    ).toBeInTheDocument();
+  });
+
   test("initialContents with non-string dateReviewed leaves field empty", async () => {
     render(
       <QueryClientProvider client={queryClient}>
@@ -284,5 +316,9 @@ describe("MenuItemReviewForm tests", () => {
     fireEvent.click(screen.getByTestId(`${testIdPrefix}-submit`));
 
     await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+    const submitted = mockSubmitAction.mock.calls[0][0];
+    expect(typeof submitted.itemId).toBe("number");
+    expect(typeof submitted.stars).toBe("number");
   });
 });

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.jsx
@@ -1,0 +1,208 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("MenuItemReviewTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "id",
+    "Menu Item ID",
+    "Reviewer Email",
+    "Stars",
+    "Date Reviewed",
+    "Comments",
+  ];
+  const expectedFields = [
+    "id",
+    "itemId",
+    "reviewerEmail",
+    "stars",
+    "dateReviewed",
+    "comments",
+  ];
+  const testId = "MenuItemReviewTable";
+
+  test("renders empty table correctly", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable reviews={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeMenuItemReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-${field}`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-reviewerEmail`),
+    ).toHaveTextContent("a@ucsb.edu");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-reviewerEmail`),
+    ).toHaveTextContent("b@ucsb.edu");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeMenuItemReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-${field}`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeMenuItemReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/menuitemreview/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/MenuItemReview")
+      .reply(200, { message: "MenuItemReview with id 1 deleted" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeMenuItemReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+});

--- a/frontend/src/tests/utils/menuItemReviewUtils.test.js
+++ b/frontend/src/tests/utils/menuItemReviewUtils.test.js
@@ -1,4 +1,18 @@
-import { toDateTimeLocalValue } from "main/utils/menuItemReviewUtils";
+import {
+  toDateTimeLocalValue,
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/menuItemReviewUtils";
+import mockConsole from "tests/testutils/mockConsole";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
 
 describe("toDateTimeLocalValue", () => {
   test("truncates ISO strings to datetime-local width", () => {
@@ -16,5 +30,36 @@ describe("toDateTimeLocalValue", () => {
     expect(toDateTimeLocalValue(undefined)).toBe("");
     expect(toDateTimeLocalValue(null)).toBe("");
     expect(toDateTimeLocalValue(7)).toBe("");
+  });
+});
+
+describe("menuItemReview delete helpers", () => {
+  describe("onDeleteSuccess", () => {
+    test("puts the message on console.log and in a toast", () => {
+      const restoreConsole = mockConsole();
+
+      onDeleteSuccess("abc");
+
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+
+  describe("cellToAxiosParamsDelete", () => {
+    test("returns the correct params", () => {
+      const cell = { row: { original: { id: 17 } } };
+
+      const result = cellToAxiosParamsDelete(cell);
+
+      expect(result).toEqual({
+        url: "/api/MenuItemReview",
+        method: "DELETE",
+        params: { id: 17 },
+      });
+    });
   });
 });

--- a/frontend/src/tests/utils/menuItemReviewUtils.test.js
+++ b/frontend/src/tests/utils/menuItemReviewUtils.test.js
@@ -1,0 +1,20 @@
+import { toDateTimeLocalValue } from "main/utils/menuItemReviewUtils";
+
+describe("toDateTimeLocalValue", () => {
+  test("truncates ISO strings to datetime-local width", () => {
+    expect(toDateTimeLocalValue("2022-04-20T00:00:00")).toBe(
+      "2022-04-20T00:00",
+    );
+  });
+
+  test("returns shorter strings unchanged", () => {
+    expect(toDateTimeLocalValue("2022-06-01T00")).toBe("2022-06-01T00");
+  });
+
+  test("returns empty for nullish or non-string", () => {
+    expect(toDateTimeLocalValue("")).toBe("");
+    expect(toDateTimeLocalValue(undefined)).toBe("");
+    expect(toDateTimeLocalValue(null)).toBe("");
+    expect(toDateTimeLocalValue(7)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
Adds frontend support for **MenuItemReview**: JavaScript fixtures that match the backend API JSON, a reusable **MenuItemReviewForm** (create + update) with validation, unit tests with full line/branch coverage, and Storybook stories for manual review and GitHub Pages.
## Changes
- `frontend/src/fixtures/menuItemReviewFixtures.js` — `oneMenuItemReview` and `threeMenuItemReviews` aligned with `GET /api/MenuItemReview` and `GET /api/MenuItemReview/all`.
- `frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx` — fields: Menu Item ID, Reviewer Email, Star rating (1–5), Date reviewed (`datetime-local` + ISO-style validation), Comments (required, max 500); `initialContents` / `submitAction` / `buttonLabel`; read-only `id` on update; `noValidate` so react-hook-form validations apply.
- `frontend/src/main/utils/menuItemReviewUtils.js` — `toDateTimeLocalValue` for API `LocalDateTime` strings → `datetime-local` input values.
- `frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx` — form behavior and validation tests.
- `frontend/src/tests/utils/menuItemReviewUtils.test.js` — helper unit tests.
- `frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.jsx` — **Create** and **Update** stories.
## How to verify locally
From `frontend/`: `nvm use 22.18.0`, then `npm test` and `npm run storybook` (see **components / MenuItemReview / MenuItemReviewForm**).
## PR artifacts
- Screenshot(s): MenuItemReviewForm in Storybook (Create and Update).
- Published Storybook (GitHub Pages):
- Closes #31 