### PR TITLE
Fix URL casing in edit/create pages and their tests

### DIFF
--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
@@ -37,7 +37,7 @@ export default function UCSBDiningCommonsMenuItemCreatePage({
   };
 
   if (isSuccess && !storybook) {
-    return <Navigate to="/diningcommonsmenuitem" />;
+    return <Navigate to="/ucsbdiningcommonsmenuitem" />;
   }
 
   return (

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx
@@ -16,11 +16,11 @@ export default function UCSBDiningCommonsMenuItemEditPage({
     _status,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
-    [`/api/ucsbdiningcommonsmenuitem?id=${id}`],
+    [`/api/UCSBDiningCommonsMenuItem?id=${id}`],
     {
       // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
       method: "GET",
-      url: `/api/ucsbdiningcommonsmenuitem`,
+      url: `/api/UCSBDiningCommonsMenuItem`,
       params: {
         id,
       },
@@ -28,7 +28,7 @@ export default function UCSBDiningCommonsMenuItemEditPage({
   );
 
   const objectToAxiosPutParams = (item) => ({
-    url: "/api/ucsbdiningcommonsmenuitem",
+    url: "/api/UCSBDiningCommonsMenuItem",
     method: "PUT",
     params: {
       id: item.id,
@@ -50,7 +50,7 @@ export default function UCSBDiningCommonsMenuItemEditPage({
     objectToAxiosPutParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    [`/api/ucsbdiningcommonsmenuitem?id=${id}`],
+    [`/api/UCSBDiningCommonsMenuItem?id=${id}`],
   );
 
   const { isSuccess } = mutation;

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.jsx
@@ -62,7 +62,7 @@ describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
     });
   });
 
-  test("on submit, makes request to backend, and redirects to /diningcommonsmenuitem", async () => {
+  test("on submit, makes request to backend, and redirects to /ucsbdiningcommonsmenuitem", async () => {
     const queryClient = new QueryClient();
     const menuItem = {
       id: 1,
@@ -119,6 +119,6 @@ describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
     expect(mockToast).toBeCalledWith(
       "New UCSBDiningCommonsMenuItem Created - id: 1 name: Pasta",
     );
-    expect(mockNavigate).toBeCalledWith({ to: "/diningcommonsmenuitem" });
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsbdiningcommonsmenuitem" });
   });
 });

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
@@ -47,7 +47,7 @@ describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
       axiosMock
-        .onGet("/api/ucsbdiningcommonsmenuitem", { params: { id: 17 } })
+        .onGet("/api/UCSBDiningCommonsMenuItem", { params: { id: 17 } })
         .timeout();
     });
 
@@ -89,14 +89,14 @@ describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
       axiosMock
-        .onGet("/api/ucsbdiningcommonsmenuitem", { params: { id: 17 } })
+        .onGet("/api/UCSBDiningCommonsMenuItem", { params: { id: 17 } })
         .reply(200, {
           id: 17,
           diningCommonsCode: "portola",
           name: "Pasta",
           station: "Entrees",
         });
-      axiosMock.onPut("/api/ucsbdiningcommonsmenuitem").reply(200, {
+      axiosMock.onPut("/api/UCSBDiningCommonsMenuItem").reply(200, {
         id: "17",
         diningCommonsCode: "portola",
         name: "Pasta Updated",


### PR DESCRIPTION
- Edit page GET/PUT calls used /api/ucsbdiningcommonsmenuitem (lowercase), now corrected to /api/UCSBDiningCommonsMenuItem to match the controller
- Create page redirect and test pointed to /diningcommonsmenuitem (missing the ucsb prefix), corrected to /ucsbdiningcommonsmenuitem
- Update all corresponding test mocks and assertions to match