### PR TITLE
Fix URL casing in table component cache key and test

### DIFF
--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.jsx
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.jsx
@@ -24,7 +24,7 @@ export default function UCSBDiningCommonsMenuItemTable({
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
-    ["/api/ucsbdiningcommonsmenuitem/all"],
+    ["/api/UCSBDiningCommonsMenuItem/all"],
   );
   // Stryker restore all
 

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.jsx
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.jsx
@@ -172,7 +172,7 @@ describe("UCSBDiningCommonsMenuItemTable tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
     axiosMock
-      .onDelete("/api/ucsbdiningcommonsmenuitem")
+      .onDelete("/api/UCSBDiningCommonsMenuItem")
       .reply(200, { message: "UCSBDiningCommonsMenuItem deleted" });
 
     render(


### PR DESCRIPTION
The delete mutation's cache invalidation key used lowercase /api/ucsbdiningcommonsmenuitem/all, which didn't match the index page's /api/UCSBDiningCommonsMenuItem/all key, so the table never refreshed after a delete. Also update the corresponding test mock URL.